### PR TITLE
Destroy and rebuild options, etc.

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -97,10 +97,10 @@ fn render_text<'a>(text: &'a str,
     let x = x * 4;
     let y = y * 4;
 
-    let mut edge_rendering = ImageBuffer::from_pixel(text_width * 4, text_height * 4, black_pixel);
-    drawing::draw_text_with_font_mut(&mut edge_rendering, white_pixel, 0, 0, scale_4x, &font, &text);
+    let mut edge_rendering = ImageBuffer::from_pixel(text_width * 4, text_height * 4, Luma([0u8]));
+    drawing::draw_text_with_font_mut(&mut edge_rendering, Luma([255u8]), 0, 0, scale_4x, &font, &text);
 
-    let edge_rendering = edges::canny(&imageops::grayscale(&edge_rendering), 245.0, 245.0);
+    let edge_rendering = edges::canny(&edge_rendering, 245.0, 245.0);
     let edge_pixels = edge_rendering.pixels().enumerate()
         .filter(|&(_, &px)| Luma([255u8]) == px)
         .map(|(idx, _)| {

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,5 @@
 use error::Cause;
-use image::{self, DynamicImage, GenericImage};
+use image::{self, DynamicImage, GenericImage, ImageFormat};
 use options::Options;
 use rusttype::{Font, FontCollection};
 use std::borrow::Cow;
@@ -66,13 +66,13 @@ impl App {
         let scale_factor = (pixels.height() as f32 / 10.0) * options.scale_mult;
 
         if options.debug {
-            let debug_image = options.annotation.render_and_debug(&mut pixels, &font, scale_factor)?;
-            save_pixels("edge.ann.png", &debug_image)?;    
+            let debug_output = options.annotations.render(&mut pixels, &font, scale_factor)?;
+            save_debug(&debug_output)?;
         } else {
-            options.annotation.render(&mut pixels, &font, scale_factor)?;
+            let _ = options.annotations.render(&mut pixels, &font, scale_factor)?;
         }
 
-        Ok(save_pixels(&options.output_path, &pixels)?)
+        Ok(save_pixels(&options.output_path, &pixels, ImageFormat::JPEG)?)
     }
 }
 
@@ -98,9 +98,12 @@ fn load_pixels(path: &Path) -> Result<DynamicImage, AppRunError> {
         .map_err(|e| AppRunError::not_found("Base image not found", Some(Box::new(e))))
 }
 
-fn save_pixels<P: AsRef<Path>>(path: P, pixels: &DynamicImage) -> Result<(), AppRunError> {
+fn save_debug(pixels: &DynamicImage) -> Result<(), AppRunError> {
+    save_pixels("debug.png", pixels, ImageFormat::PNG)
+}
+
+fn save_pixels<P: AsRef<Path>>(path: P, pixels: &DynamicImage, format: ImageFormat) -> Result<(), AppRunError> {
     use std::fs::OpenOptions;
-    use image::ImageFormat;
 
     let mut out = OpenOptions::new()
         .write(true)
@@ -109,6 +112,6 @@ fn save_pixels<P: AsRef<Path>>(path: P, pixels: &DynamicImage) -> Result<(), App
         .open(path.as_ref())
         .map_err(|e| AppRunError::io("Unable to write to output", Some(Box::new(e))))?;
 
-    pixels.save(&mut out, ImageFormat::JPEG)
+    pixels.save(&mut out, format)
         .map_err(|e| AppRunError::io("Unable to save image to output", Some(Box::new(e))))
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -61,18 +61,18 @@ impl error::Error for AppRunError {
 
 impl App {
     pub fn run(&self, options: &Options) -> Result<(), AppRunError> {
-        let font = build_font(options.font_path())?;
-        let mut pixels = load_pixels(options.base_image())?;
-        let scale_factor = (pixels.height() as f32 / 10.0) * options.scale_multiplier();
+        let font = build_font(&options.font_path)?;
+        let mut pixels = load_pixels(&options.base_image)?;
+        let scale_factor = (pixels.height() as f32 / 10.0) * options.scale_mult;
 
-        if options.debug() {
-            let debug_image = options.annotation().render_and_debug(&mut pixels, &font, scale_factor)?;
+        if options.debug {
+            let debug_image = options.annotation.render_and_debug(&mut pixels, &font, scale_factor)?;
             save_pixels("edge.ann.png", &debug_image)?;    
         } else {
-            options.annotation().render(&mut pixels, &font, scale_factor)?;
+            options.annotation.render(&mut pixels, &font, scale_factor)?;
         }
 
-        Ok(save_pixels(options.output_path(), &pixels)?)
+        Ok(save_pixels(&options.output_path, &pixels)?)
     }
 }
 
@@ -109,6 +109,6 @@ fn save_pixels<P: AsRef<Path>>(path: P, pixels: &DynamicImage) -> Result<(), App
         .open(path.as_ref())
         .map_err(|e| AppRunError::io("Unable to write to output", Some(Box::new(e))))?;
 
-    pixels.save(&mut out, ImageFormat::PNG)
+    pixels.save(&mut out, ImageFormat::JPEG)
         .map_err(|e| AppRunError::io("Unable to save image to output", Some(Box::new(e))))
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -72,7 +72,7 @@ impl App {
             let _ = options.annotations.render(&mut pixels, &font, scale_factor)?;
         }
 
-        Ok(save_pixels(&options.output_path, &pixels, ImageFormat::JPEG)?)
+        Ok(save_pixels(&options.output_path, &pixels, options.output_format.into())?)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,12 @@ fn main() {
     match Options::from_args() {
         Ok(options) => {
             if let Err(e) = App.run(&options) {
-                println!("{}", e);
+                use std::error::Error;
+                if let Some(cause) = e.cause() {
+                    println!("{}: {}", e, cause);
+                } else {
+                    println!("{}", e);
+                }
                 process::exit(1);
             }
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,41 +9,17 @@ use std::path::{Path, PathBuf};
 // string but a path buffer itself is technically not because it isn't validated UTF8?
 
 pub struct Options {
-    base_image: PathBuf,
-    annotation: Annotation,
-    output_path: PathBuf,
-    scale_mult: f32,
-    font_path: PathBuf,
-    debug: bool,
+    pub base_image: PathBuf,
+    pub annotation: Annotation,
+    pub output_path: PathBuf,
+    pub scale_mult: f32,
+    pub font_path: PathBuf,
+    pub debug: bool,
 }
 
 impl Options {
     pub fn from_args() -> Result<Self, BuildOptionsError> {
         read_command()
-    }
-
-    pub fn base_image(&self) -> &Path {
-        &self.base_image
-    }
-
-    pub fn font_path(&self) -> &Path {
-        &self.font_path
-    }
-
-    pub fn scale_multiplier(&self) -> f32 {
-        self.scale_mult
-    }
-
-    pub fn annotation(&self) -> &Annotation {
-        &self.annotation
-    }
-
-    pub fn output_path(&self) -> &Path {
-        &self.output_path
-    }
-
-    pub fn debug(&self) -> bool {
-        self.debug
     }
 }
 
@@ -219,6 +195,6 @@ fn create_output_file_path(input_path: &Path) -> PathBuf {
     if let Some(last_segment_idx) = file_name.rfind('.') {
         file_name.truncate(last_segment_idx);
     }
-    file_name.push_str(".ann.png");
+    file_name.push_str(".ann.jpg");
     file_name.into()
 }


### PR DESCRIPTION
Interface completely redone. There will probably be one more interface change, but it will be invisible to users... I just need a way to specify everything about a given bit of text. We'll see how that goes.

This version allows you to set top, middle, and bottom text, with each one being rendered separately to the text layer before the text layer is overlaid onto the image.